### PR TITLE
Se agregaron omisiones para el archivo gitignore; Obejtos .RData de R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ meta-data/Araport11_GFF3_genes_transposons.201606.gtf
 meta-data/Athaliana_447_TAIR10.fa
 meta-data/trash/
 meta-data/Araport11_GFF3.gff
+
+# Objetos creados por los scripts R que son demasiado grandes para almacenarse en el repo con el metodo convencional
+# csc/23-marzo-2022
+WGCNA_RScripts/*.RData


### PR DESCRIPTION
Se agregaron omisiones para el archivo gitignore; debera ignorar los  objetos de datos creados por los scripts de R con extensión RData, debido a que algunos de estos son muy grandes para almacenarse en el remoto de forma convencional. 